### PR TITLE
Added py_version back in smmp and smdp tests

### DIFF
--- a/test/sagemaker_tests/huggingface_pytorch/training/integration/sagemaker/test_smdp.py
+++ b/test/sagemaker_tests/huggingface_pytorch/training/integration/sagemaker/test_smdp.py
@@ -71,7 +71,7 @@ def can_run_smdataparallel(ecr_image):
 @pytest.mark.processor("gpu")
 @pytest.mark.skip_cpu
 @pytest.mark.skip_py2_containers
-def test_smdp_question_answering(ecr_image, instance_type, sagemaker_session, tmpdir):
+def test_smdp_question_answering(ecr_image, instance_type, py_version, sagemaker_session, tmpdir):
     """
     Tests SM Distributed DataParallel single-node via script mode
     """
@@ -89,6 +89,7 @@ def test_smdp_question_answering(ecr_image, instance_type, sagemaker_session, tm
             instance_count=instance_count,
             instance_type=instance_type,
             sagemaker_session=sagemaker_session,
+            py_version=py_version,
             distribution=distribution,
             hyperparameters=hyperparameters,
         )
@@ -101,7 +102,7 @@ def test_smdp_question_answering(ecr_image, instance_type, sagemaker_session, tm
 @pytest.mark.processor("gpu")
 @pytest.mark.skip_cpu
 @pytest.mark.skip_py2_containers
-def test_smdp_question_answering_multinode(ecr_image, instance_type, sagemaker_session, tmpdir):
+def test_smdp_question_answering_multinode(ecr_image, instance_type, py_version, sagemaker_session, tmpdir):
     """
     Tests SM Distributed DataParallel single-node via script mode
     """
@@ -120,6 +121,7 @@ def test_smdp_question_answering_multinode(ecr_image, instance_type, sagemaker_s
             instance_count=instance_count,
             instance_type=instance_type,
             sagemaker_session=sagemaker_session,
+            py_version=py_version,
             distribution=distribution,
             hyperparameters=hyperparameters,
         )

--- a/test/sagemaker_tests/huggingface_pytorch/training/integration/sagemaker/test_smmp.py
+++ b/test/sagemaker_tests/huggingface_pytorch/training/integration/sagemaker/test_smmp.py
@@ -64,7 +64,7 @@ git_config = {'repo': 'https://github.com/huggingface/notebooks.git', 'branch': 
 @pytest.mark.model("hf_qa_smmp")
 @pytest.mark.skip_cpu
 @pytest.mark.skip_py2_containers
-def test_smmp_gpu(sagemaker_session, framework_version, ecr_image, instance_type, dist_gpu_backend):
+def test_smmp_gpu(sagemaker_session, framework_version, ecr_image, instance_type, py_version, dist_gpu_backend):
     # instance configurations
     instance_type = instance_type or 'ml.p3.16xlarge'
     instance_count = 1
@@ -79,6 +79,7 @@ def test_smmp_gpu(sagemaker_session, framework_version, ecr_image, instance_type
                                         role='SageMakerRole',
                                         image_uri=ecr_image,
                                         distribution=distribution,
+                                        py_version=py_version,
                                         hyperparameters=hyperparameters,
                                         sagemaker_session=sagemaker_session)
     huggingface_estimator.fit(job_name=sagemaker.utils.unique_name_from_base('test-hf-pt-qa-smmp'))
@@ -90,7 +91,7 @@ def test_smmp_gpu(sagemaker_session, framework_version, ecr_image, instance_type
 @pytest.mark.skip_cpu
 @pytest.mark.skip_py2_containers
 @pytest.mark.multinode(2)
-def test_smmp_gpu_multinode(sagemaker_session, framework_version, ecr_image, instance_type, dist_gpu_backend):
+def test_smmp_gpu_multinode(sagemaker_session, framework_version, ecr_image, instance_type, py_version, dist_gpu_backend):
     instance_type = instance_type or 'ml.p3.16xlarge'
     instance_count = 2
     volume_size = 400
@@ -104,6 +105,7 @@ def test_smmp_gpu_multinode(sagemaker_session, framework_version, ecr_image, ins
                                         role='SageMakerRole',
                                         image_uri=ecr_image,
                                         distribution=distribution,
+                                        py_version=py_version,
                                         hyperparameters=hyperparameters,
                                         sagemaker_session=sagemaker_session)
     huggingface_estimator.fit(job_name=sagemaker.utils.unique_name_from_base('test-hf-pt-qa-smmp-multi'))


### PR DESCRIPTION
Run smdp test with: 

` pytest integration/sagemaker/test_smdp.py --region us-east-1 --docker-base-name huggingface-pytorch-training --tag 1.6.0-transformers4.4.2-gpu-py36-cu110-ubuntu18.04 --framework-version 1.6.0 --aws-id 763104351884 --instance-type ml.p3.16xlarge`

